### PR TITLE
BGS bug fix, use modes and overlay

### DIFF
--- a/scripts/bgs_vibe_alike.py
+++ b/scripts/bgs_vibe_alike.py
@@ -4,35 +4,42 @@
 import numpy as np
 import cv2
 import time
+from collections import deque
+from numba import njit, prange
 from multiprocessing import shared_memory
 import multiprocessing.resource_tracker as resource_tracker
-from numba import njit, prange
-from collections import deque
 
-# Constants
-CAM_SHM_NAME = "cam_ring_buffer"
-META_SHM_NAME = "metadata_ring_buffer"
+# SETTINGS
+LIVE_MODE = True  # ← set to False to process SHM sequentially (pre-loaded from hdf5 file)
 RING_SIZE = 200
 FULL_SHAPE = (3200, 3200)
-DOWNSAMPLE = 4 # 1 .. 7-9FPS, 2 .. 27-31FPS, 4 .. 82-100FPS
-FRAME_SHAPE = (FULL_SHAPE[0] // DOWNSAMPLE, FULL_SHAPE[1] // DOWNSAMPLE)  # 800x800px
-PIXEL_SIZE = 2  # uint16
-HISTORY_LEN = 50
+DOWNSAMPLE = 2
+FRAME_SHAPE = (FULL_SHAPE[0] // DOWNSAMPLE, FULL_SHAPE[1] // DOWNSAMPLE)
+PIXEL_SIZE = 2
+HISTORY_LEN = 30
 FG_HISTORY_LEN = 5
-MATCH_THRESHOLD = 6400 * 3 # lower = stricter match → more foreground, higher = looser match → less foreground
-REQUIRED_MATCHES = 2 # higher = harder to be background → more foreground, lower = easier to be background → less foreground
-window_title = "BGS static test viewer - press 'q' to quit."
-morph_open = 3 # [1,3,5,7, ...]
-morph_close = 3 # [1,3,5,7, ...]
-random_max = 8
+MATCH_THRESHOLD = 1600 # [0..32767]
+REQUIRED_MATCHES = 2
+window_title = "Live BGS viewer - press 'q' to quit."
+morph_open = 5
+morph_close = 5
+USE_RANDOM_UPDATE = True  # set True to use original ViBe random replacement
+if USE_RANDOM_UPDATE:
+    print("using ViBe random replacement")
+else:
+    print("using Richards min/max replacement")
 
-# Derivates
+# SHM settings
+CAM_SHM_NAME = "cam_ring_buffer"
+META_SHM_NAME = "metadata_ring_buffer"
+meta_dtype = np.dtype([("timestamp", "f8"), ("exposure", "f8"), ("gain", "f8")])
+
+# FG smoothing
 fg_mask_history = deque(maxlen=FG_HISTORY_LEN)
 
-# Processing frame-wise in a JIT binary 
 @njit(parallel=True)
-def process_frame(curr_frame: np.ndarray, history: np.ndarray,
-                  match_threshold: int, required_matches: int) -> (np.ndarray, np.ndarray):
+def process_frame(curr_frame: np.ndarray, history: np.ndarray, match_threshold: int, required_matches: int, use_random_update: bool) -> (np.ndarray, np.ndarray):
+
     height, width = curr_frame.shape
     fg_mask = np.zeros((height, width), dtype=np.uint8)
     hist_len = history.shape[2]
@@ -43,117 +50,135 @@ def process_frame(curr_frame: np.ndarray, history: np.ndarray,
             samples = history[y, x, :]
             match_count = 0
 
-            min_val = samples[0]
-            max_val = samples[0]
+            min_val = max_val = samples[0]
+            min_idx = max_idx = 0
+
             for i in range(hist_len):
                 s = samples[i]
                 if abs(int(s) - int(px)) < match_threshold:
                     match_count += 1
                 if s < min_val:
                     min_val = s
-                if s > max_val:
+                    min_idx = i
+                elif s > max_val:
                     max_val = s
+                    max_idx = i
 
             if match_count >= required_matches:
-                # pixel is background
-                if np.random.randint(random_max) == 1:
-                    if min_val <= px <= max_val:
-                        # Replace a random index not equal to min or max
-                        min_idx = -1
-                        max_idx = -1
-                        for i in range(hist_len):
-                            if samples[i] == min_val and min_idx == -1:
-                                min_idx = i
-                            elif samples[i] == max_val and max_idx == -1:
-                                max_idx = i
-                        # Choose any index but min_idx and max_idx
-                        while True:
-                            ri = np.random.randint(hist_len)
-                            if ri != min_idx and ri != max_idx:
-                                break
-                        history[y, x, ri] = px
+                # background
+                if use_random_update:
+                    # ViBe original: randomly choose a sample to update
+                    history[y, x, np.random.randint(hist_len)] = px
+                    # changing a second pixel
+                    history[y, x, np.random.randint(hist_len)] = px
+                    history[y, x, np.random.randint(hist_len)] = px
+                else:
+                    # Richard logic: update either min or max
+                    if abs(int(min_val) - int(px)) > abs(int(max_val) - int(px)):
+                        history[y, x, min_idx] = px
                     else:
-                        # Replace the one farther from px (either min or max)
-                        if abs(int(min_val) - int(px)) > abs(int(max_val) - int(px)):
-                            # Replace min
-                            for i in range(hist_len):
-                                if samples[i] == min_val:
-                                    history[y, x, i] = px
-                                    break
-                        else:
-                            # Replace max
-                            for i in range(hist_len):
-                                if samples[i] == max_val:
-                                    history[y, x, i] = px
-                                    break
+                        history[y, x, max_idx] = px
             else:
-                # pixel is foreground
+                # foreground
                 fg_mask[y, x] = 255
 
     return fg_mask, history
 
-# Connect to SHMs
-image_bytes = np.prod(FULL_SHAPE) * PIXEL_SIZE * RING_SIZE
-meta_dtype = np.dtype([("timestamp", "d"), ("exposure", "f"), ("gain", "f")])
-meta_bytes = RING_SIZE * meta_dtype.itemsize
+def get_newest_index(timestamps: np.ndarray) -> int:
+    return int(np.argmax(timestamps))
 
+# Attach to shared memory (identical for live and offline mode)
 image_shm = shared_memory.SharedMemory(name=CAM_SHM_NAME)
 meta_shm = shared_memory.SharedMemory(name=META_SHM_NAME)
-
 resource_tracker.unregister(image_shm._name, 'shared_memory')
 resource_tracker.unregister(meta_shm._name, 'shared_memory')
 
-# Downsampled image view
 image_np = np.ndarray((RING_SIZE, *FULL_SHAPE), dtype=np.uint16, buffer=image_shm.buf)[:, ::DOWNSAMPLE, ::DOWNSAMPLE]
 meta_np = np.ndarray((RING_SIZE,), dtype=meta_dtype, buffer=meta_shm.buf)
 
-# Sort by timestamp
-#sorted_indices = np.argsort(meta_np["timestamp"])
-start_idx = np.argmin(meta_np["timestamp"])
-ordered_indices = [(start_idx + i) % RING_SIZE for i in range(RING_SIZE)]
-
-# Init history
+# Initialize history
 history = np.zeros((*FRAME_SHAPE, HISTORY_LEN), dtype=np.uint16)
+print("Waiting for sufficient history frames...")
+
+while True:
+    timestamps = meta_np["timestamp"]
+    if np.count_nonzero(timestamps > 0) >= HISTORY_LEN:
+        break
+    print("Waiting for frames...", flush=True)
+    time.sleep(0.1)
+
+latest_idx = get_newest_index(meta_np["timestamp"])
+if LIVE_MODE:
+    start_idx = latest_idx
+else:
+    start_idx = (latest_idx - HISTORY_LEN + 1) % RING_SIZE
+
+ordered_indices = [(start_idx + i) % RING_SIZE for i in range(HISTORY_LEN)]
+for i, idx in enumerate(ordered_indices):
+    history[:, :, i] = image_np[idx]
+
+print("History initialized. Starting processing loop...")
+prev_latest_idx = start_idx
+
+cv2.namedWindow(window_title, cv2.WINDOW_NORMAL)
+cv2.resizeWindow(window_title, FRAME_SHAPE[1], FRAME_SHAPE[0])
 
 try:
-    print(f"Initializing history with first {HISTORY_LEN} frames...")
-    for i in range(HISTORY_LEN):
-        frame = image_np[ordered_indices[i]]
-        history[:, :, i] = frame
-    print("History initialized.")
+    while True:
+        timestamps = meta_np["timestamp"]
+        if LIVE_MODE:
+            current_idx = get_newest_index(timestamps)
+            if current_idx == prev_latest_idx:
+                time.sleep(0.001)
+                continue
+        else:
+            current_idx = (prev_latest_idx + 1) % RING_SIZE
+            if timestamps[current_idx] == 0:
+                print("End of offline data.")
+                break
 
-    print("Running BGS on remaining frames...")
-    for rel_idx in range(HISTORY_LEN, RING_SIZE):
-        idx = ordered_indices[rel_idx]
-        frame = image_np[idx]
+        frame = image_np[current_idx]
+        prev_latest_idx = current_idx
 
         start_time = time.perf_counter()
-        fg_mask, history = process_frame(frame, history, MATCH_THRESHOLD, REQUIRED_MATCHES)
-        
-        # Apply morphological opening to remove small noise patches
-        fg_mask = cv2.morphologyEx(fg_mask, cv2.MORPH_OPEN, np.ones((morph_open, morph_open), np.uint8))
-        
-        # Apply morphological closing to fill small holes
-        fg_mask = cv2.morphologyEx(fg_mask, cv2.MORPH_CLOSE, np.ones((morph_close, morph_close), np.uint8))
-        
-        # Begin temporal smoothing
+        fg_mask, history = process_frame(frame, history, MATCH_THRESHOLD, REQUIRED_MATCHES, USE_RANDOM_UPDATE)
+
+        if morph_open > 1:
+            fg_mask = cv2.morphologyEx(fg_mask, cv2.MORPH_OPEN, np.ones((morph_open, morph_open), np.uint8))
+        if morph_close > 1:
+            fg_mask = cv2.morphologyEx(fg_mask, cv2.MORPH_CLOSE, np.ones((morph_close, morph_close), np.uint8))
+
         fg_mask_history.append(fg_mask.copy())
         if len(fg_mask_history) == FG_HISTORY_LEN:
             stacked = np.stack(fg_mask_history, axis=0)
             stable_fg_mask = (np.sum(stacked, axis=0) > (255 * FG_HISTORY_LEN // 2)).astype(np.uint8) * 255
         else:
             stable_fg_mask = fg_mask
-        
+
         fps = 1 / (time.perf_counter() - start_time)
-        num_fg_pixels = np.count_nonzero(stable_fg_mask) / stable_fg_mask.size * 100 # [%]
-        print(f"Frame {rel_idx}/{RING_SIZE}: {fps:.2f} FPS, foreground pixels: {num_fg_pixels:.2f}%")
-        
-        cv2.imshow(window_title, stable_fg_mask)
-        
+        num_fg_pixels = np.count_nonzero(stable_fg_mask) / stable_fg_mask.size * 100
+        print(f"Frame {current_idx}: {fps:.2f} FPS, foreground pixels: {num_fg_pixels:.2f}%")
+
+        # Convert 16-bit frame to 8-bit for display
+        frame_display = (frame.astype(np.float32) / 256).astype(np.uint8)
+
+        # Convert to 3-channel RGB
+        frame_rgb = cv2.cvtColor(frame_display, cv2.COLOR_BayerRG2RGB)
+
+        # Colorize the foreground mask (e.g., red)
+        overlay_color = np.zeros_like(frame_rgb)
+        overlay_color[:, :, 2] = stable_fg_mask  # Red channel only
+
+        # Blend the overlay with the original frame
+        alpha = 0.8  # Transparency factor: 0 = transparent, 1 = opaque
+        blended = cv2.addWeighted(frame_rgb, 1.0, overlay_color, alpha, 0)
+
+        # Display the result
+        cv2.imshow(window_title, blended)
+
         if cv2.waitKey(1) & 0xFF == ord('q'):
             print("Quit requested.")
             break
-        time.sleep(0.1)
 
 except KeyboardInterrupt:
     print("Interrupted.")

--- a/scripts/viewer_qhy_camera.py
+++ b/scripts/viewer_qhy_camera.py
@@ -51,7 +51,7 @@ def show_frame(index):
     #cv2.putText(scaled_img_8bit, f"Timestamp: {metadata_buffer[index][0]}", (10, 55), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2, cv2.LINE_AA)
     cv2.putText(scaled_img_8bit, f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(metadata_buffer[index][0]))}", (10, 55), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2, cv2.LINE_AA)
     
-    cv2.putText(scaled_img_8bit, f"Exposure: {metadata_buffer[index][1]:.2f} ms", (10, 85), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2, cv2.LINE_AA)
+    cv2.putText(scaled_img_8bit, f"Exposure: {metadata_buffer[index][1]:.2f} µs", (10, 85), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2, cv2.LINE_AA)
     
     cv2.putText(scaled_img_8bit, f"Gain: {metadata_buffer[index][2]:.2f}", (10, 115), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2, cv2.LINE_AA)
 

--- a/src/camera_controler/QHYCameraController.py
+++ b/src/camera_controler/QHYCameraController.py
@@ -194,7 +194,7 @@ class QHYCameraController:
     MIN_GRAB_TIME_SEC = 0.102 # [s] minimum grabbing estimate for first delay
     RING_BUFFER_FRAMES = 200  # number of frames in ring buffer
     MAX_FRAME_GRABS = 10 # max number of successful frame grabs during calibration
-    EXPOSURE_ADJUST_INTERVAL = 3 # Frequency of exposure/gain adjustments
+    EXPOSURE_ADJUST_INTERVAL = 4 # Frequency of exposure/gain adjustments
 
     # Buffer & Processing Parameters
     FRAME_SYNC_DELAY_STEP = -0.001  # Decreasing delay step with new frame grabs [seconds]
@@ -406,7 +406,7 @@ class QHYCameraController:
             if debug: print(f"Initialization: successfully began live mode ✅")
         else:
             if debug: print(f"Initialization: failed to begin live mode ❌")
-        time.sleep(0.5)
+        time.sleep(0.2)
 
     def get_single_frame(self):
         if debug: print(f"Calibration: fetching 3 single frames ...")
@@ -592,7 +592,7 @@ if __name__ == "__main__":
         img = qhy_camera.get_live_frame()
 
         if img is not None and debug:
-            fps = 1 / (time.perf_counter() - prev_time + qhy_camera.delay)
+            fps = 1 / (time.perf_counter() - prev_time)
             qhy_camera.ring_buffer.frame_index
             if debug: print(f"Live: Index={qhy_camera.ring_buffer.frame_index}, FPS={fps:.1f} ✅")
             


### PR DESCRIPTION
- fg mask pixels are now overlayed over the bg pixels
- bug in addressing the metadata corrected
- 2 ways of using the data: LIVE_MODE = True (False reads from SHMs created by the camera_dump_to_shm.py script)
- 2 ways of using the BGS: USE_RANDOM_UPDATE = True (False uses min/max, True uses random indizes for substituting history pixels)
- changing several pixels is an experiment (history[y, x, np.random.randint(hist_len)] = px)
- viewer shows life frame as bg, overlayed with fg_mask pixels in red