### PR TITLE
QHYCameraController and usb_traffic_monitor updates

### DIFF
--- a/tools/USB_tools/usb_traffic_monitor.sh
+++ b/tools/USB_tools/usb_traffic_monitor.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 sudo modprobe usbmon
-sudo usbtop --bus usbmon2
+sudo usbtop --bus usbmon8


### PR DESCRIPTION
**QHYCameraController**
- turned the image processing into a grey image (part of AE update() function) into a NJIT logic
- USB_SPEED for testing variations (to no success so far)
- renewed delay estimation (moved it back to the controller)
- re-aquisition of image data if failed before

**usb_traffic_monitor updates**
- used bus 8 (instead of 2) aka USB-C port on the Orange Pi5+